### PR TITLE
Migration timeout

### DIFF
--- a/backend/src/db/migrationScript.ts
+++ b/backend/src/db/migrationScript.ts
@@ -3,41 +3,24 @@
 
   Not really using a public API.
 */
-import { PrismaClientInitializationError } from '@prisma/client/runtime';
 import { Migrate } from '@prisma/migrate/dist/Migrate.js';
 import { ensureDatabaseExists } from '@prisma/migrate/dist/utils/ensureDatabaseExists';
 import { printFilesFromMigrationIds } from '@prisma/migrate/dist/utils/printFiles';
 import chalk from 'chalk';
-import { sleep } from 'common';
 import { getPrisma, loadDatabaseUrl } from './client';
 
 export const handler = async (): Promise<string> => {
   const schemaPath = './schema.prisma';
   const dbUrl = await loadDatabaseUrl();
 
+  // add longer connection timeout in case the DB is sleeping
+  const url = new URL(dbUrl);
+  url.searchParams.set('pool_timeout', '60');
+
   // get DB connection
-  try {
-    const client = await getPrisma();
-    await client.$connect();
-  } catch (ex) {
-    const errorCode = (ex as PrismaClientInitializationError).errorCode;
-    if (errorCode == 'P1001') {
-      // timed out waiting to reach DB server
-      // it might be waking up from slumber
-      // so retry in a short bit
-      console.warn('Database not yet available, retrying...');
-      await sleep(25_000);
-      console.info('Retrying...');
-
-      const client = await getPrisma();
-      await client.$connect();
-    } else {
-      console.error('Failed to run database migrations');
-      throw ex;
-    }
-  }
-
-  process.env.DATABASE_URL = dbUrl;
+  process.env.DATABASE_URL = url.toString();
+  const client = await getPrisma();
+  await client.$connect();
 
   const migrate = new Migrate(schemaPath);
   const wasDbCreated = await ensureDatabaseExists('apply', true, schemaPath);

--- a/backend/src/db/migrationScript.ts
+++ b/backend/src/db/migrationScript.ts
@@ -15,7 +15,7 @@ export const handler = async (): Promise<string> => {
 
   // add longer connection timeout in case the DB is sleeping
   const url = new URL(dbUrl);
-  url.searchParams.set('pool_timeout', '60');
+  url.searchParams.set('pool_timeout', '120');
 
   // get DB connection
   process.env.DATABASE_URL = url.toString();

--- a/stacks/web.ts
+++ b/stacks/web.ts
@@ -21,7 +21,7 @@ export function Web({ stack }: StackContext) {
         }
       : undefined,
     environment: {
-      NEXTAUTH_SECRET: secrets.secret.secretValueFromJson(secret('APP')).toString(),
+      NEXTAUTH_SECRET: secrets.secret.secretValueFromJson(secret('APP')).toString(), // FIXME https://github.com/nextauthjs/next-auth/discussions/5145 & https://github.com/serverless-stack/sst/issues/1986
       NEXTAUTH_URL: 'http://localhost:6020', // FIXME: how to pass in this URL?
       NEXT_PUBLIC_REGION: stack.region,
       NEXT_PUBLIC_APPSYNC_ENDPOINT: appSyncApi.api.url,


### PR DESCRIPTION
Instead of retrying, increase DB connection timeout when running migrations in case the DB was asleep