### PR TITLE
Cognito token refresh with fetch

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,7 +178,6 @@ importers:
   web:
     specifiers:
       '@apollo/client': ^3.6.5
-      '@aws-sdk/client-cognito-identity-provider': ~3.145.0
       '@babel/core': ^7.17.8
       '@emotion/react': ^11.8.1
       '@emotion/styled': ^11.8.1
@@ -242,7 +241,6 @@ importers:
       zen-observable: ^0.8.15
     dependencies:
       '@apollo/client': 3.6.5_aez2jvt6lsvokp3l4ousdbdxf4
-      '@aws-sdk/client-cognito-identity-provider': 3.145.0
       '@emotion/react': 11.9.0_vgpkcqmg5a4hir44jyrcc6lmou
       '@emotion/styled': 11.8.1_o46hbkuvnkqmb6a7zjhdu7enjy
       '@mui/icons-material': 5.8.0_qp2nnmfemvntiuc2rkhvgzmqpy
@@ -713,48 +711,6 @@ packages:
     resolution: {integrity: sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==}
     dependencies:
       tslib: 2.4.0
-    dev: false
-
-  /@aws-sdk/client-cognito-identity-provider/3.145.0:
-    resolution: {integrity: sha512-LKfrD0KPT26+PbOLfyGJyIzZLQ7onujgb1qRiuICr1D06A9E5CS0jXZEKeU/4+EUUc8boWlrN9meif6P/fyK/g==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 2.0.0
-      '@aws-crypto/sha256-js': 2.0.0
-      '@aws-sdk/client-sts': 3.145.0
-      '@aws-sdk/config-resolver': 3.130.0
-      '@aws-sdk/credential-provider-node': 3.145.0
-      '@aws-sdk/fetch-http-handler': 3.131.0
-      '@aws-sdk/hash-node': 3.127.0
-      '@aws-sdk/invalid-dependency': 3.127.0
-      '@aws-sdk/middleware-content-length': 3.127.0
-      '@aws-sdk/middleware-host-header': 3.127.0
-      '@aws-sdk/middleware-logger': 3.127.0
-      '@aws-sdk/middleware-recursion-detection': 3.127.0
-      '@aws-sdk/middleware-retry': 3.127.0
-      '@aws-sdk/middleware-serde': 3.127.0
-      '@aws-sdk/middleware-signing': 3.130.0
-      '@aws-sdk/middleware-stack': 3.127.0
-      '@aws-sdk/middleware-user-agent': 3.127.0
-      '@aws-sdk/node-config-provider': 3.127.0
-      '@aws-sdk/node-http-handler': 3.127.0
-      '@aws-sdk/protocol-http': 3.127.0
-      '@aws-sdk/smithy-client': 3.142.0
-      '@aws-sdk/types': 3.127.0
-      '@aws-sdk/url-parser': 3.127.0
-      '@aws-sdk/util-base64-browser': 3.109.0
-      '@aws-sdk/util-base64-node': 3.55.0
-      '@aws-sdk/util-body-length-browser': 3.55.0
-      '@aws-sdk/util-body-length-node': 3.55.0
-      '@aws-sdk/util-defaults-mode-browser': 3.142.0
-      '@aws-sdk/util-defaults-mode-node': 3.142.0
-      '@aws-sdk/util-user-agent-browser': 3.127.0
-      '@aws-sdk/util-user-agent-node': 3.127.0
-      '@aws-sdk/util-utf8-browser': 3.109.0
-      '@aws-sdk/util-utf8-node': 3.109.0
-      tslib: 2.4.0
-    transitivePeerDependencies:
-      - aws-crt
     dev: false
 
   /@aws-sdk/client-kms/3.145.0:

--- a/stacks/web.ts
+++ b/stacks/web.ts
@@ -20,7 +20,7 @@ export function Web({ stack }: StackContext) {
         }
       : undefined,
     environment: {
-      // NEXTAUTH_URL: 'http://localhost:6020', // FIXME: how to pass in this URL?
+      NEXTAUTH_URL: 'http://localhost:6020', // FIXME: how to pass in this URL?
       NEXTAUTH_SECRET: secrets.secret.secretValueFromJson('RANDOM').toString(), // FIXME https://github.com/nextauthjs/next-auth/discussions/5145 & https://github.com/serverless-stack/sst/issues/1986
       NEXT_PUBLIC_REGION: stack.region,
       NEXT_PUBLIC_APPSYNC_ENDPOINT: appSyncApi.api.url,

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.5",
-    "@aws-sdk/client-cognito-identity-provider": "~3.145.0",
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",
     "@mui/icons-material": "^5.5.1",

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -21,17 +21,15 @@ const refreshCognitoAccessToken = async (tokens: JWT): Promise<CognitoRefreshTok
     body: Object.entries({
       grant_type: 'refresh_token',
       client_id: COGNITO_CLIENT_ID,
-      redirect_uri: window.location.origin,
-      refresh_token: tokens.refresh_token,
+      refresh_token: tokens.refreshToken,
     })
       .map(([k, v]) => `${k}=${v}`)
       .join('&'),
   });
   if (!res.ok) {
-    throw new Error(await res.json());
+    throw new Error(JSON.stringify(await res.json()));
   }
   const newTokens = await res.json();
-  console.log('newTokens', newTokens);
   return newTokens;
 };
 

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -33,15 +33,6 @@ const refreshCognitoAccessToken = async (tokens: JWT): Promise<CognitoRefreshTok
   const newTokens = await res.json();
   console.log('newTokens', newTokens);
   return newTokens;
-
-  //   AuthFlow: AuthFlowType.REFRESH_TOKEN_AUTH,
-  //   ClientId: COGNITO_CLIENT_ID,
-  //   AuthParameters: {
-  //     REFRESH_TOKEN: token.refreshToken as string,
-  //   },
-  // });
-  // const response = await client.send(command);
-  // return response.AuthenticationResult;
 };
 
 export const authOptions: NextAuthOptions = {


### PR DESCRIPTION
Allows us to drop `@aws-sdk/client-cognito-identity-provider` from dependencies and should save a few tens or hundreds of ms off cold start times for nextjs