### PR TITLE
feat: use env vars for setting up LinkedIn id & secret

### DIFF
--- a/stacks/secrets.ts
+++ b/stacks/secrets.ts
@@ -1,14 +1,21 @@
 import { StackContext } from '@serverless-stack/resources';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 
+const LINKEDIN_CLIENT_ID = process.env.LINKEDIN_CLIENT_ID;
+const LINKEDIN_CLIENT_SECRET = process.env.LINKEDIN_CLIENT_SECRET;
+
 export function Secrets({ stack, app }: StackContext) {
+  if (!LINKEDIN_CLIENT_ID || !LINKEDIN_CLIENT_SECRET) {
+    throw new Error('You need to define LINKEDIN_CLIENT_ID and LINKEDIN_CLIENT_SECRET in your environment variables');
+  }
+
   const secret = new Secret(stack, 'Secret', {
     description: app.logicalPrefixedName('app'),
     generateSecretString: {
       secretStringTemplate: JSON.stringify({
         // optional
-        ['LINKEDIN_CLIENT_ID']: 'changeme',
-        ['LINKEDIN_CLIENT_SECRET']: 'changeme',
+        ['LINKEDIN_CLIENT_ID']: LINKEDIN_CLIENT_ID,
+        ['LINKEDIN_CLIENT_SECRET']: LINKEDIN_CLIENT_SECRET,
       }),
       generateStringKey: 'RANDOM', // unused
     },
@@ -21,3 +28,4 @@ export function Secrets({ stack, app }: StackContext) {
 
   return { secret };
 }
+


### PR DESCRIPTION
## Summary

The idea of this PR is to set LinkedIn ClientID & ClientSecret at stack creation.

If the environment vars haven't been set, throws an error indicating so.